### PR TITLE
FE-2552: Fix previous release branch lookup to use natural version sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [5.0.1] - 14.05.2026
+
+- Fix previous release branch lookup to use natural version sort (avoids picking `2.9` over `2.12`)
+
 ## [5.0.0] - 02.09.2022
 
 - Added full history between RC and Release

--- a/dist/index.js
+++ b/dist/index.js
@@ -9129,7 +9129,7 @@ const execSyncToString = (command) =>{
  * @returns {string}
  */
 const getBaseCommit = (project, defaultBranch) => {
-    const previousReleaseBranch = execSyncToString(`git branch -r --list '**/release/${project}/**' | tail -1`);
+    const previousReleaseBranch = execSyncToString(`git branch -r --list '**/release/${project}/**' --sort=-version:refname | head -1`);
 
     // return initial commit on main branch as fallback
     if (!previousReleaseBranch) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cactus",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cactus",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.8.2",
@@ -55,6 +55,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -276,6 +277,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cactus",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Cactus Release Manager",
   "main": "action.yml",
   "scripts": {

--- a/src/git.js
+++ b/src/git.js
@@ -17,7 +17,7 @@ const execSyncToString = (command) =>{
  * @returns {string}
  */
 export const getBaseCommit = (project, defaultBranch) => {
-    const previousReleaseBranch = execSyncToString(`git branch -r --list '**/release/${project}/**' | tail -1`);
+    const previousReleaseBranch = execSyncToString(`git branch -r --list '**/release/${project}/**' --sort=-version:refname | head -1`);
 
     // return initial commit on main branch as fallback
     if (!previousReleaseBranch) {


### PR DESCRIPTION
The scheduled cut workflow in [`zattoo/frontend`](https://github.com/zattoo/frontend/actions/runs/25787977336) created `release/embed/2.13` from a stale commit because Cactus picked the wrong "previous" release branch. The lookup in `src/git.js` used `git branch -r --list ... | tail -1`, which sorts lexicographically — so `release/embed/2.9` ranked above `release/embed/2.12`. The base commit then resolved to `merge-base(master, 2.9)`, miles behind master.

Switching to `--sort=-version:refname | head -1` uses git's built-in natural version sort (available since git 2.7), and `2.12` correctly outranks `2.9`. `dist/index.js` was rebuilt with `npm run pack`, and `CHANGELOG.md` + `package.json` were bumped to `5.0.1`.

The `v5` branch needs to be advanced to this commit after merge so the `zattoo/cactus@v5` pin in consumer workflows picks the fix up.

Tracked in [FE-2557](https://zattoo2.atlassian.net/browse/FE-2557).

[FE-2557]: https://zattoo2.atlassian.net/browse/FE-2557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ